### PR TITLE
destroy legend to avoid overplotting it

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: d3scatter
 Type: Package
 Title: Demo of d3 scatter plot; testbed for crosstalk library
-Version: 0.1.0
+Version: 0.1.1
 Authors@R: c(
     person("Joe", "Cheng", role = c("aut", "cre"), email = "joe@rstudio.com"),
     person(family = "RStudio", role = "cph"),

--- a/inst/htmlwidgets/lib/d3scatter/d3scatter.js
+++ b/inst/htmlwidgets/lib/d3scatter/d3scatter.js
@@ -147,6 +147,7 @@ function d3scatter(container) {
         });
 
     if (props.color_spec && color.domain) {
+      svg.selectAll(".legend").remove();
       var legend = svg.selectAll(".legend")
           .data(color.domain());
       var legendNew = legend.enter().append("g")


### PR DESCRIPTION
There seems to be an issue with the legend being overplotted instead of being replaced when you programmatically change the color variable. I think this change fixes it.

This should demonstrate the behavior. I love this package. Thank you for your hard work!

```
library(shiny)
library(d3scatter)
library(crosstalk)
library(DT)
library(ggplot2)

mysamp=sample(1:nrow(diamonds),1000)
myd=diamonds[mysamp,]
sharedD=SharedData$new(myd)

runapp<-function(){
shinyApp(
	ui <- fluidPage(
	    titlePanel("crosstalkd3Select"),
            sidebarLayout(position = "left",
                sidebarPanel(width=2, selectInput("filterVar","Filter Column",names(myd))),
            mainPanel("",width=10,
		d3scatterOutput("scatter1"),
		dataTableOutput('mytable')
		 
))),

	server <- function(input, output, session) {

	    output$scatter1 <- renderD3scatter({
		colVar=input$filterVar
		d3scatter(sharedD, ~carat, ~price,as.formula(paste0("~",colVar)))}) 
	    output$mytable = renderDataTable(sharedD,options = list(scrollX = TRUE,pageLength=5),server=FALSE)
	}
)}
runapp()
```